### PR TITLE
Update to Exposed v1.0.0-beta-5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,7 @@ kotlin {
 dependencies {
     detektPlugins(libs.detekt.formatting)
     implementation(libs.exposed.core)
+    implementation(libs.exposed.jdbc)
     implementation(libs.kotlinx.serialization)
     implementation(libs.ktor.server.core)
     testImplementation(kotlin("test"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,10 +4,10 @@
 
 detekt = "1.23.7"
 dokka = "2.0.0"
-exposed = "0.61.0"
+exposed = "1.0.0-beta-5"
 kotlin = "2.1.20"
 kotlinx-serialization = "1.8.1"
-ktor = "3.1.2"
+ktor = "3.2.2"
 vanniktech = "0.30.0"
 
 
@@ -51,6 +51,7 @@ detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", 
 # https://github.com/JetBrains/Exposed
 # https://github.com/JetBrains/Exposed/blob/main/docs/ChangeLog.md
 exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
+exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
 
 # Serialization (part of the pLugin).
 # https://github.com/Kotlin/kotlinx.serialization/releases

--- a/src/main/kotlin/io/perracodex/exposed/pagination/MapModel.kt
+++ b/src/main/kotlin/io/perracodex/exposed/pagination/MapModel.kt
@@ -4,7 +4,7 @@
 
 package io.perracodex.exposed.pagination
 
-import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.v1.core.ResultRow
 
 /**
  * Contract for mapping a database [ResultRow] into an instance of type [T].

--- a/src/main/kotlin/io/perracodex/exposed/pagination/PageableQuery.kt
+++ b/src/main/kotlin/io/perracodex/exposed/pagination/PageableQuery.kt
@@ -5,7 +5,12 @@
 package io.perracodex.exposed.pagination
 
 import io.perracodex.exposed.utils.QuerySorter
-import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.countDistinct
+import org.jetbrains.exposed.v1.jdbc.Query
+import org.jetbrains.exposed.v1.jdbc.andWhere
+import org.jetbrains.exposed.v1.jdbc.select
 
 /**
  * Retrieves a page from this [Query] based on the specified [pageable] parameters.

--- a/src/main/kotlin/io/perracodex/exposed/utils/QuerySorter.kt
+++ b/src/main/kotlin/io/perracodex/exposed/utils/QuerySorter.kt
@@ -6,10 +6,12 @@ package io.perracodex.exposed.utils
 
 import io.perracodex.exposed.pagination.Pageable
 import io.perracodex.exposed.pagination.PaginationError
-import org.jetbrains.exposed.sql.Column
-import org.jetbrains.exposed.sql.Query
-import org.jetbrains.exposed.sql.SortOrder
-import org.jetbrains.exposed.sql.Table
+import io.perracodex.exposed.utils.QuerySorter.columnCache
+import io.perracodex.exposed.utils.QuerySorter.generateCacheKey
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.jdbc.Query
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.full.memberProperties
 


### PR DESCRIPTION
Changes:

- Upgraded Exposed to v1.0.0-beta-5 from version 0.61.0
- Added exposed-jdbc dependency for SQL query support
- Updated Ktor to version 3.2.2 from 3.1.2
- Migrated to new Exposed v1 package structure:
    - Replaced org.jetbrains.exposed.sql.* imports with org.jetbrains.exposed.v1.core.* and org.jetbrains.exposed.v1.jdbc.*
    - Updated imports across all pagination and utility files

Technical Details:

- Added exposed-jdbc dependency in build.gradle.kts to support Query operations
- Updated all imports for compatibility with the new Exposed v1 architecture
- Maintains full pagination functionality with the new APIs