### PR TITLE
Add support for position-based pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,9 +221,10 @@ fun Application.configureStatusPages() {
 ### Syntax
 
 You can use HTTP query parameters to control pagination and sorting in your API endpoints.
+- **Pagination (page/size):** `?page=0&size=10`
+- **Pagination (position/size):** `?position=15&size=10` — starts from absolute element position 15
 
-- **Pagination:** `?page=0&size=10`
-
+Note: `page` and `position` are mutually exclusive; do not provide both in the same request.
 - **Sorting:** `?sort=fieldName,direction`
 
 - **Sorting (multiple fields):** `?sort=fieldName_A,direction_A&sort=fieldName_B,direction_B`
@@ -258,7 +259,12 @@ No pagination, sorted by first name, default to ascending:
 `GET` http://localhost:8080/v1/employees?sort=firstName
 ```
 
----
+Start from absolute position 15, 10 elements per page (equivalent content to page=1 with size=10, but accepts any start
+index):
+
+```bash
+GET http://localhost:8080/v1/employees?position=15&size=10&sort=firstName,asc
+```
 
 ### Resolving Field Ambiguity
 

--- a/src/main/kotlin/io/perracodex/exposed/pagination/Page.kt
+++ b/src/main/kotlin/io/perracodex/exposed/pagination/Page.kt
@@ -25,6 +25,7 @@ public data class Page<out T : Any>(
      *
      * @property totalPages The total number of pages available based on the pagination parameters.
      * @property pageIndex The zero-based index of the current page.
+     * @property position The absolute zero-based starting position (offset).
      * @property totalElements The aggregate number of elements across all pages.
      * @property elementsPerPage The maximum number of elements that can be contained in a single page.
      * @property elementsInPage The actual number of elements present in the current page.
@@ -39,6 +40,7 @@ public data class Page<out T : Any>(
     public data class PageDetails(
         val totalPages: Int,
         val pageIndex: Int,
+        val position: Int,
         val totalElements: Int,
         val elementsPerPage: Int,
         val elementsInPage: Int,
@@ -70,8 +72,13 @@ public data class Page<out T : Any>(
                 0
             }
 
-            // Determine the current page index.
-            val pageIndex: Int = pageable?.page ?: 0
+            // Determine the current page and position indexes
+            val (pageIndex, positionIndex) = when {
+                pageable == null -> 0 to 0
+                pageSize <= 0 -> 0 to 0
+                pageable.position != null -> pageable.position / pageSize to pageable.position
+                else -> pageable.page to pageable.page * pageSize
+            }
 
             // Adjust pagination state based on total pages and content availability.
             val elementsInPage: Int = content.size
@@ -90,6 +97,7 @@ public data class Page<out T : Any>(
                 details = PageDetails(
                     totalPages = totalPages,
                     pageIndex = pageIndex,
+                    position = positionIndex,
                     totalElements = totalElements,
                     elementsPerPage = pageSize,
                     elementsInPage = elementsInPage,

--- a/src/main/kotlin/io/perracodex/exposed/pagination/Pageable.kt
+++ b/src/main/kotlin/io/perracodex/exposed/pagination/Pageable.kt
@@ -10,17 +10,20 @@ import kotlinx.serialization.Serializable
  * Encapsulates the parameters required to request a specific page of data from a paginated dataset.
  *
  * @property page The zero-based index of the page to retrieve.
+ * @property position Optional absolute zero-based starting position within the full result set.
  * @property size The maximum number of elements to include in a single page. `0` to return all elements without pagination.
  * @property sort An optional list of [PageSort] directives to order the results.
  */
 @Serializable
 public data class Pageable(
     val page: Int,
+    val position: Int?,
     val size: Int,
     val sort: List<PageSort>? = null
 ) {
     init {
         require(value = (page >= 0)) { "Page index must be >= 0." }
+        require(value = (position == null || position >= 0)) { "Position must be >= 0 when provided." }
         require(value = (size >= 0)) { "Page size must be >= 0. (0 means all elements)." }
     }
 

--- a/src/main/kotlin/io/perracodex/exposed/pagination/PageableQuery.kt
+++ b/src/main/kotlin/io/perracodex/exposed/pagination/PageableQuery.kt
@@ -156,7 +156,9 @@ public fun <T : Any, K> Query.paginate(
  *
  * This extension function modifies the query in the following ways:
  * 1. **Sorting:** If [pageable] includes sorting directives, they are applied to the [Query].
- * 2. **Limiting:** Uses page number and size to set the query’s limit and offset.
+ * 2. **Limiting and offset:**
+ *    - If [pageable.position] is defined, it is used as the absolute zero-based starting position (offset).
+ *    - Otherwise, the offset is calculated from the page number as `page * size`.
  *
  * If [pageable] is `null`, or the defined page size is `0`, the entire result set is retrieved without any pagination,
  * and a [Page] containing all domain models is returned.
@@ -174,7 +176,7 @@ public fun Query.paginate(pageable: Pageable?): Query {
         }
 
         if (pageable.size > 0) {
-            val startIndex: Long = pageable.page.toLong() * pageable.size.toLong()
+            val startIndex: Long = pageable.position?.toLong() ?: (pageable.page.toLong() * pageable.size.toLong())
             this.limit(count = pageable.size)
                 .offset(start = startIndex)
         }

--- a/src/main/kotlin/io/perracodex/exposed/pagination/PaginationError.kt
+++ b/src/main/kotlin/io/perracodex/exposed/pagination/PaginationError.kt
@@ -41,7 +41,7 @@ public sealed class PaginationError(
      */
     public class InvalidPageablePair : PaginationError(
         errorCode = "INVALID_PAGEABLE_PAIR",
-        description = "Page attributes mismatch. Expected both 'page' and 'size', or none of them.",
+        description = "Page attributes mismatch. Use either 'page'+'size' or 'position'+'size' (mutually exclusive), or none.",
     )
 
     /**

--- a/src/main/kotlin/io/perracodex/exposed/utils/PageableKeys.kt
+++ b/src/main/kotlin/io/perracodex/exposed/utils/PageableKeys.kt
@@ -12,6 +12,9 @@ internal enum class PageableKeys(val key: String) {
     /** The query parameter key for the page index. */
     PAGE("page"),
 
+    /** The query parameter key for the absolute starting position (offset). */
+    POSITION("position"),
+
     /** The query parameter key for the page size. */
     SIZE("size"),
 


### PR DESCRIPTION
## ✨ Changes
- Introduced **absolute position (`position`)** as an alternative to page-based pagination.
- Updated documentation (`README.md`) with usage examples:
  - `?page=2&size=10` — classic page-based pagination.
  - `?position=15&size=10` — new position-based pagination.
- Added a new `position` field to:
  - **Page** — stores the absolute starting position.
  - **Pageable** — supports `position` in API queries.
  - **PageableRequest** — parses `position` from HTTP params.
- Updated **PageableQuery**:
  - Uses `position` as `OFFSET` if provided.
  - Falls back to `page * size` if not.
- Added **POSITION** constant in `PageableKeys`.
- Improved error handling in **PaginationError**:
  - `page` and `position` are mutually exclusive.
  - Both require `size` to be set.

## 🔒 Backward Compatibility
- Existing `page+size` queries work exactly as before.
- New behavior is only triggered when `position` is provided.
- Error messages are now more descriptive.